### PR TITLE
Pass options to super

### DIFF
--- a/lib/state_machines/integrations/active_record.rb
+++ b/lib/state_machines/integrations/active_record.rb
@@ -454,8 +454,8 @@ module StateMachines
       def define_state_initializer
         if ::ActiveRecord.gem_version >= Gem::Version.new('5.0.0.alpha')
           define_helper :instance, <<-end_eval, __FILE__, __LINE__ + 1
-            def initialize(attributes = nil, *)
-              super(attributes) do |*args|
+            def initialize(attributes = nil, options = {})
+              super(attributes, options) do |*args|
                 scoped_attributes = (attributes || {}).merge(self.class.scope_attributes)
 
                 self.class.state_machines.initialize_states(self, {}, scoped_attributes)

--- a/lib/state_machines/integrations/active_record/version.rb
+++ b/lib/state_machines/integrations/active_record/version.rb
@@ -1,7 +1,7 @@
 module StateMachines
   module Integrations
     module ActiveRecord
-      VERSION = '0.6.1'
+      VERSION = '0.6.1-sd'
     end
   end
 end

--- a/lib/state_machines/integrations/active_record/version.rb
+++ b/lib/state_machines/integrations/active_record/version.rb
@@ -1,7 +1,7 @@
 module StateMachines
   module Integrations
     module ActiveRecord
-      VERSION = '0.6.0'
+      VERSION = '0.6.1'
     end
   end
 end

--- a/state_machines-activerecord.gemspec
+++ b/state_machines-activerecord.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'state_machines-activemodel', '>= 0.5.0'
-  spec.add_dependency 'activerecord' , '>= 4.1'
+  spec.add_dependency 'activerecord' , ['>= 4.1', '< 6.0']
   spec.add_development_dependency 'rake', '~> 10.3'
   spec.add_development_dependency 'sqlite3', '~> 1.3'
   spec.add_development_dependency 'appraisal', '>= 1'


### PR DESCRIPTION
I'll be opening a PR to get this into the original repo at some point.

naked asterisk doesn't play well with default values on attributes declared on parent.

need to pass `options` explicitly to super when options has a default value in the parent.

fixes this error in our code base:
https://github.com/snapdocs/snapdocs/blob/develop/app/models/automated_search.rb#L29

not sure if i need to bump the gem version or the dependency version. limiting to rails < 6.0 to make sure to revisit this gem when we upgrade to v6.0