### PR TITLE
Allow gem to be used with Rails 6.1

### DIFF
--- a/lib/state_machines/integrations/active_record/version.rb
+++ b/lib/state_machines/integrations/active_record/version.rb
@@ -1,7 +1,7 @@
 module StateMachines
   module Integrations
     module ActiveRecord
-      VERSION = '0.6.1-sd'
+      VERSION = '0.6.2-sd'
     end
   end
 end

--- a/state_machines-activerecord.gemspec
+++ b/state_machines-activerecord.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'state_machines-activemodel', '>= 0.5.0'
-  spec.add_dependency 'activerecord' , ['>= 4.1', '< 6.0']
+  spec.add_dependency 'activerecord' , ['>= 4.1', '< 6.2']
   spec.add_development_dependency 'rake', '~> 10.3'
   spec.add_development_dependency 'sqlite3', '~> 1.3'
   spec.add_development_dependency 'appraisal', '>= 1'


### PR DESCRIPTION
I'm working on upgrading the monolith to Rails 6: [JIRA](https://snapdocs-eng.atlassian.net/browse/CORE-1274). This forked gem was explicitly marked incompatible so we'd revisit it at this time. Unfortunately, the original reason for this fork being created, namely that `options` is not being passed to `super` in an initializer, still exists in the 'official' gem. According to railsbump, this version (0.6.0) is otherwise compatible with Rails 6. Therefore, I'm kicking the can down the road a few versions so I can upgrade Rails to 6.1.